### PR TITLE
Make binary tree code dry

### DIFF
--- a/Learning.xcodeproj/project.pbxproj
+++ b/Learning.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		662377DB2464829100EF35C0 /* SubsetSum.swift in Sources */ = {isa = PBXBuildFile; fileRef = 662377DA2464829100EF35C0 /* SubsetSum.swift */; };
 		662377DE2465FA0100EF35C0 /* Heap.swift in Sources */ = {isa = PBXBuildFile; fileRef = 662377DD2465FA0100EF35C0 /* Heap.swift */; };
 		662377E02465FBCF00EF35C0 /* BinaryTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 662377DF2465FBCF00EF35C0 /* BinaryTree.swift */; };
+		662377E22467296600EF35C0 /* AnyBinaryTree.swift in Sources */ = {isa = PBXBuildFile; fileRef = 662377E12467296600EF35C0 /* AnyBinaryTree.swift */; };
 		668C35B5245DE44F008E2D2C /* BinarySearch.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668C35B4245DE44F008E2D2C /* BinarySearch.swift */; };
 		668C35B8245DF060008E2D2C /* MaximumSubarrayDivideAndConquer.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668C35B7245DF060008E2D2C /* MaximumSubarrayDivideAndConquer.swift */; };
 		668C35BB245E066C008E2D2C /* MaximumSubarrayKadane.swift in Sources */ = {isa = PBXBuildFile; fileRef = 668C35BA245E066C008E2D2C /* MaximumSubarrayKadane.swift */; };
@@ -48,6 +49,7 @@
 		662377DC2464965300EF35C0 /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
 		662377DD2465FA0100EF35C0 /* Heap.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Heap.swift; sourceTree = "<group>"; };
 		662377DF2465FBCF00EF35C0 /* BinaryTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinaryTree.swift; sourceTree = "<group>"; };
+		662377E12467296600EF35C0 /* AnyBinaryTree.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AnyBinaryTree.swift; sourceTree = "<group>"; };
 		668C35B4245DE44F008E2D2C /* BinarySearch.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BinarySearch.swift; sourceTree = "<group>"; };
 		668C35B7245DF060008E2D2C /* MaximumSubarrayDivideAndConquer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MaximumSubarrayDivideAndConquer.swift; sourceTree = "<group>"; };
 		668C35B9245E0285008E2D2C /* README.md */ = {isa = PBXFileReference; lastKnownFileType = net.daringfireball.markdown; path = README.md; sourceTree = "<group>"; };
@@ -247,6 +249,7 @@
 		66EAB861245669CA00593625 /* Trees */ = {
 			isa = PBXGroup;
 			children = (
+				662377E12467296600EF35C0 /* AnyBinaryTree.swift */,
 				662377DF2465FBCF00EF35C0 /* BinaryTree.swift */,
 				66EAB8682459A85E00593625 /* BinarySearchTree.swift */,
 				662377DD2465FA0100EF35C0 /* Heap.swift */,
@@ -322,6 +325,7 @@
 				662377E02465FBCF00EF35C0 /* BinaryTree.swift in Sources */,
 				668C35B8245DF060008E2D2C /* MaximumSubarrayDivideAndConquer.swift in Sources */,
 				669E0C352451DCF6003DD940 /* SieveOfEratosthenes.swift in Sources */,
+				662377E22467296600EF35C0 /* AnyBinaryTree.swift in Sources */,
 				662377DE2465FA0100EF35C0 /* Heap.swift in Sources */,
 				66EAB85424538FD900593625 /* MergeSort.swift in Sources */,
 				668C35B5245DE44F008E2D2C /* BinarySearch.swift in Sources */,

--- a/Learning/Algorithms/BinarySearchTreeReconstruction/BinarySearchTreeReconstruction.swift
+++ b/Learning/Algorithms/BinarySearchTreeReconstruction/BinarySearchTreeReconstruction.swift
@@ -7,7 +7,7 @@
 //
 
 extension BinarySearchTree {
-    convenience init(inOrderTraversal: [T], preOrderTraversal: [T]) {
+    convenience init(inOrderTraversal: [Element], preOrderTraversal: [Element]) {
         self.init()
         
     }

--- a/Learning/Data Structures/Trees/AnyBinaryTree.swift
+++ b/Learning/Data Structures/Trees/AnyBinaryTree.swift
@@ -1,0 +1,91 @@
+//
+//  AnyBinaryTree.swift
+//  Learning
+//
+//  Created by Artem Zhukov on 09.05.20.
+//  Copyright © 2020 Artem Zhukov. All rights reserved.
+//
+
+//protocol BinaryTreeNodePr {
+//    associatedtype T
+//    associatedtype Node = Self
+//    var value: T { get set }
+//    var leftChild: Node? { get set }
+//    var rightChild: Node? { get set }
+//    var parent: Node? { get set }
+//    //init(_ value: T)
+//}
+//
+//enum TraversalOrder {
+//    /// Pre-order traversal first traverses the root, then the left subtree, and then the right subtree.
+//    case preOrder
+//    /// In-order traversal first traverses the left subtree, then the root, and then the right subtree.
+//    case inOrder
+//    /// Post-order traversal first traverses the left subtree, then the right subtree, and then the root.
+//    case postOrder
+//}
+//protocol BinaryTreePr {
+//    associatedtype T
+//    associatedtype Node where Node: BinaryTreeNodePr
+//    //associatedtype TraversalOrder
+//    var root: Node? { get }
+//    var count: Int { get }
+//    var isEmpty: Bool { get }
+//    var inOrderTraversal: [T] { get }
+//    var preOrderTraversal: [T] { get }
+//    var postOrderTraversal: [T] { get }
+//    func traverse(_ order: TraversalOrder, action: (T) -> ())
+//}
+//extension BinaryTreePr {
+//    var isEmpty: Bool {
+//        return count == 0
+//    }
+//    var inOrderTraversal: [T] {
+//        var array: [T] = []
+//        traverseInOrder(startingWith: root, action: { array.append($0) })
+//        return array
+//    }
+//    var preOrderTraversal: [T] {
+//        var array: [T] = []
+//        traversePreOrder(startingWith: root, action: { array.append($0) })
+//        return array
+//    }
+//    var postOrderTraversal: [T] {
+//        var array: [T] = []
+//        traversePostOrder(startingWith: root, action: { array.append($0) })
+//        return array
+//    }
+//}
+//extension BinaryTreePr {
+//    func traverse(_ order: TraversalOrder, action: (T) -> ()) {
+//        switch order {
+//            case .preOrder:
+//                traversePreOrder(startingWith: root, action: action)
+//            case .inOrder:
+//                traverseInOrder(startingWith: root, action: action)
+//            case .postOrder:
+//                traversePostOrder(startingWith: root, action: action)
+//        }
+//    }
+//    private func traverseInOrder(startingWith node: Node?, action: (T) -> ()) {
+//        if let node = node {
+//            traverseInOrder(startingWith: node.leftChild as? Node, action: action)
+//            action(node.value as! T)
+//            traverseInOrder(startingWith: node.rightChild as? Node, action: action)
+//        }
+//    }
+//    private func traversePreOrder(startingWith node: Node?, action: (T) -> ()) {
+//        if let node = node {
+//            action(node.value as! T)
+//            traversePreOrder(startingWith: node.leftChild as? Node, action: action)
+//            traversePreOrder(startingWith: node.rightChild as? Node, action: action)
+//        }
+//    }
+//    private func traversePostOrder(startingWith node: Node?, action: (T) -> ()) {
+//        if let node = node {
+//            traversePostOrder(startingWith: node.leftChild as? Node, action: action)
+//            traversePostOrder(startingWith: node.rightChild as? Node, action: action)
+//            action(node.value as! T)
+//        }
+//    }
+//}

--- a/Learning/Data Structures/Trees/AnyBinaryTree.swift
+++ b/Learning/Data Structures/Trees/AnyBinaryTree.swift
@@ -15,77 +15,77 @@ protocol BinaryTreeNodePr {
     var parent: Node? { get set }
     //init(_ value: T)
 }
-//
-//enum TraversalOrder {
-//    /// Pre-order traversal first traverses the root, then the left subtree, and then the right subtree.
-//    case preOrder
-//    /// In-order traversal first traverses the left subtree, then the root, and then the right subtree.
-//    case inOrder
-//    /// Post-order traversal first traverses the left subtree, then the right subtree, and then the root.
-//    case postOrder
-//}
-//protocol BinaryTreePr {
-//    associatedtype T
-//    associatedtype Node where Node: BinaryTreeNodePr
-//    //associatedtype TraversalOrder
-//    var root: Node? { get }
-//    var count: Int { get }
-//    var isEmpty: Bool { get }
-//    var inOrderTraversal: [T] { get }
-//    var preOrderTraversal: [T] { get }
-//    var postOrderTraversal: [T] { get }
-//    func traverse(_ order: TraversalOrder, action: (T) -> ())
-//}
-//extension BinaryTreePr {
-//    var isEmpty: Bool {
-//        return count == 0
-//    }
-//    var inOrderTraversal: [T] {
-//        var array: [T] = []
-//        traverseInOrder(startingWith: root, action: { array.append($0) })
-//        return array
-//    }
-//    var preOrderTraversal: [T] {
-//        var array: [T] = []
-//        traversePreOrder(startingWith: root, action: { array.append($0) })
-//        return array
-//    }
-//    var postOrderTraversal: [T] {
-//        var array: [T] = []
-//        traversePostOrder(startingWith: root, action: { array.append($0) })
-//        return array
-//    }
-//}
-//extension BinaryTreePr {
-//    func traverse(_ order: TraversalOrder, action: (T) -> ()) {
-//        switch order {
-//            case .preOrder:
-//                traversePreOrder(startingWith: root, action: action)
-//            case .inOrder:
-//                traverseInOrder(startingWith: root, action: action)
-//            case .postOrder:
-//                traversePostOrder(startingWith: root, action: action)
-//        }
-//    }
-//    private func traverseInOrder(startingWith node: Node?, action: (T) -> ()) {
-//        if let node = node {
-//            traverseInOrder(startingWith: node.leftChild as? Node, action: action)
-//            action(node.value as! T)
-//            traverseInOrder(startingWith: node.rightChild as? Node, action: action)
-//        }
-//    }
-//    private func traversePreOrder(startingWith node: Node?, action: (T) -> ()) {
-//        if let node = node {
-//            action(node.value as! T)
-//            traversePreOrder(startingWith: node.leftChild as? Node, action: action)
-//            traversePreOrder(startingWith: node.rightChild as? Node, action: action)
-//        }
-//    }
-//    private func traversePostOrder(startingWith node: Node?, action: (T) -> ()) {
-//        if let node = node {
-//            traversePostOrder(startingWith: node.leftChild as? Node, action: action)
-//            traversePostOrder(startingWith: node.rightChild as? Node, action: action)
-//            action(node.value as! T)
-//        }
-//    }
-//}
+
+enum TraversalOrder {
+    /// Pre-order traversal first traverses the root, then the left subtree, and then the right subtree.
+    case preOrder
+    /// In-order traversal first traverses the left subtree, then the root, and then the right subtree.
+    case inOrder
+    /// Post-order traversal first traverses the left subtree, then the right subtree, and then the root.
+    case postOrder
+}
+protocol BinaryTreePr {
+    associatedtype T
+    associatedtype Node where Node: BinaryTreeNodePr
+    //associatedtype TraversalOrder
+    var root: Node? { get }
+    var count: Int { get }
+    var isEmpty: Bool { get }
+    var inOrderTraversal: [T] { get }
+    var preOrderTraversal: [T] { get }
+    var postOrderTraversal: [T] { get }
+    func traverse(_ order: TraversalOrder, action: (T) -> ())
+}
+extension BinaryTreePr {
+    var isEmpty: Bool {
+        return count == 0
+    }
+    var inOrderTraversal: [T] {
+        var array: [T] = []
+        traverseInOrder(startingWith: root, action: { array.append($0) })
+        return array
+    }
+    var preOrderTraversal: [T] {
+        var array: [T] = []
+        traversePreOrder(startingWith: root, action: { array.append($0) })
+        return array
+    }
+    var postOrderTraversal: [T] {
+        var array: [T] = []
+        traversePostOrder(startingWith: root, action: { array.append($0) })
+        return array
+    }
+}
+extension BinaryTreePr {
+    func traverse(_ order: TraversalOrder, action: (T) -> ()) {
+        switch order {
+            case .preOrder:
+                traversePreOrder(startingWith: root, action: action)
+            case .inOrder:
+                traverseInOrder(startingWith: root, action: action)
+            case .postOrder:
+                traversePostOrder(startingWith: root, action: action)
+        }
+    }
+    private func traverseInOrder(startingWith node: Node?, action: (T) -> ()) {
+        if let node = node {
+            traverseInOrder(startingWith: node.leftChild as? Node, action: action)
+            action(node.value as! T)
+            traverseInOrder(startingWith: node.rightChild as? Node, action: action)
+        }
+    }
+    private func traversePreOrder(startingWith node: Node?, action: (T) -> ()) {
+        if let node = node {
+            action(node.value as! T)
+            traversePreOrder(startingWith: node.leftChild as? Node, action: action)
+            traversePreOrder(startingWith: node.rightChild as? Node, action: action)
+        }
+    }
+    private func traversePostOrder(startingWith node: Node?, action: (T) -> ()) {
+        if let node = node {
+            traversePostOrder(startingWith: node.leftChild as? Node, action: action)
+            traversePostOrder(startingWith: node.rightChild as? Node, action: action)
+            action(node.value as! T)
+        }
+    }
+}

--- a/Learning/Data Structures/Trees/AnyBinaryTree.swift
+++ b/Learning/Data Structures/Trees/AnyBinaryTree.swift
@@ -8,9 +8,9 @@
 
 // MARK: - Node
 protocol AnyBinaryTreeNode {
-    associatedtype T
+    associatedtype Element
     associatedtype Node = Self
-    var value: T { get set }
+    var value: Element { get set }
     var leftChild: Node? { get set }
     var rightChild: Node? { get set }
     var parent: Node? { get set }
@@ -18,40 +18,40 @@ protocol AnyBinaryTreeNode {
 
 // MARK: - Tree
 protocol AnyBinaryTree {
-    associatedtype T
+    associatedtype Element
     associatedtype Node where Node: AnyBinaryTreeNode
     var root: Node? { get }
     var count: Int { get }
     var isEmpty: Bool { get }
-    var inOrderTraversal: [T] { get }
-    var preOrderTraversal: [T] { get }
-    var postOrderTraversal: [T] { get }
-    func traverse(_ order: TraversalOrder, action: (T) -> ())
+    var inOrderTraversal: [Element] { get }
+    var preOrderTraversal: [Element] { get }
+    var postOrderTraversal: [Element] { get }
+    func traverse(_ order: TraversalOrder, action: (Element) -> ())
 }
 // MARK: Property implementations
 extension AnyBinaryTree {
     var isEmpty: Bool {
         return count == 0
     }
-    var inOrderTraversal: [T] {
-        var array: [T] = []
+    var inOrderTraversal: [Element] {
+        var array: [Element] = []
         traverseInOrder(startingWith: root, action: { array.append($0) })
         return array
     }
-    var preOrderTraversal: [T] {
-        var array: [T] = []
+    var preOrderTraversal: [Element] {
+        var array: [Element] = []
         traversePreOrder(startingWith: root, action: { array.append($0) })
         return array
     }
-    var postOrderTraversal: [T] {
-        var array: [T] = []
+    var postOrderTraversal: [Element] {
+        var array: [Element] = []
         traversePostOrder(startingWith: root, action: { array.append($0) })
         return array
     }
 }
 // MARK: Method implementations
 extension AnyBinaryTree {
-    func traverse(_ order: TraversalOrder, action: (T) -> ()) {
+    func traverse(_ order: TraversalOrder, action: (Element) -> ()) {
         switch order {
             case .preOrder:
                 traversePreOrder(startingWith: root, action: action)
@@ -61,25 +61,25 @@ extension AnyBinaryTree {
                 traversePostOrder(startingWith: root, action: action)
         }
     }
-    private func traverseInOrder(startingWith node: Node?, action: (T) -> ()) {
+    private func traverseInOrder(startingWith node: Node?, action: (Element) -> ()) {
         if let node = node {
             traverseInOrder(startingWith: node.leftChild as? Node, action: action)
-            action(node.value as! T)
+            action(node.value as! Element)
             traverseInOrder(startingWith: node.rightChild as? Node, action: action)
         }
     }
-    private func traversePreOrder(startingWith node: Node?, action: (T) -> ()) {
+    private func traversePreOrder(startingWith node: Node?, action: (Element) -> ()) {
         if let node = node {
-            action(node.value as! T)
+            action(node.value as! Element)
             traversePreOrder(startingWith: node.leftChild as? Node, action: action)
             traversePreOrder(startingWith: node.rightChild as? Node, action: action)
         }
     }
-    private func traversePostOrder(startingWith node: Node?, action: (T) -> ()) {
+    private func traversePostOrder(startingWith node: Node?, action: (Element) -> ()) {
         if let node = node {
             traversePostOrder(startingWith: node.leftChild as? Node, action: action)
             traversePostOrder(startingWith: node.rightChild as? Node, action: action)
-            action(node.value as! T)
+            action(node.value as! Element)
         }
     }
 }
@@ -93,7 +93,7 @@ enum TraversalOrder {
 }
 
 // MARK: - Printability
-protocol StringConvertibleBinarySubtree: CustomStringConvertible where Self: AnyBinaryTreeNode, Self.T: CustomStringConvertible {
+protocol StringConvertibleBinarySubtree: CustomStringConvertible where Self: AnyBinaryTreeNode, Self.Element: CustomStringConvertible {
 }
 extension StringConvertibleBinarySubtree {
     /// A horizontal textual representation of the binary search tree.

--- a/Learning/Data Structures/Trees/AnyBinaryTree.swift
+++ b/Learning/Data Structures/Trees/AnyBinaryTree.swift
@@ -92,44 +92,6 @@ enum TraversalOrder {
 }
 
 // MARK: - Miscellaneous
-func clean(string: inout [[Character]]) {
-    var maxLineLength = 0
-    for line in 0..<string.count {  // indent all lines (for a e s t h e t i c s) O(n^2)
-        let first = string[line][0]
-        if first != "│" && first != "┌" && first != "└" {
-            string[line] = "──── " + string[line] // O(n)
-        } else {
-            string[line] = "     " + string[line] // O(n)
-        }
-        maxLineLength = max(maxLineLength, string[line].count)
-    }
-    for col in stride(from: 0, to: maxLineLength, by: 5) { // O(n^2)
-        var removing = true
-        for row in 0..<string.count {
-            if col >= string[row].count {
-                removing = true
-                continue
-            }
-            let character = string[row][col]
-            if col > 0 && character != "│" && character != "┌" && character != "└" && string[row][col-1] != " " {
-                removing = true
-                continue
-            }
-            if character == "┌" {
-                removing = false
-            }
-            if removing && character == "│" {
-                string[row][col] = " "
-            } else if removing {
-                removing = false
-            }
-            if character == "└" {
-                removing = true
-            }
-        }
-    }
-}
-
 protocol StringConvertibleBinaryTree: CustomStringConvertible where Self: AnyBinaryTreeNode, Self.T: CustomStringConvertible {
 }
 extension StringConvertibleBinaryTree {
@@ -155,7 +117,41 @@ extension StringConvertibleBinaryTree {
     var description: String {
         var string: [[Character]] = []
         constructString(self, &string, 0) // O(nlogn)
-        clean(string: &string)
+        var maxLineLength = 0
+        for line in 0..<string.count {  // indent all lines (for a e s t h e t i c s) O(n^2)
+            let first = string[line][0]
+            if first != "│" && first != "┌" && first != "└" {
+                string[line] = "──── " + string[line] // O(n)
+            } else {
+                string[line] = "     " + string[line] // O(n)
+            }
+            maxLineLength = max(maxLineLength, string[line].count)
+        }
+        for col in stride(from: 0, to: maxLineLength, by: 5) { // O(n^2)
+            var removing = true
+            for row in 0..<string.count {
+                if col >= string[row].count {
+                    removing = true
+                    continue
+                }
+                let character = string[row][col]
+                if col > 0 && character != "│" && character != "┌" && character != "└" && string[row][col-1] != " " {
+                    removing = true
+                    continue
+                }
+                if character == "┌" {
+                    removing = false
+                }
+                if removing && character == "│" {
+                    string[row][col] = " "
+                } else if removing {
+                    removing = false
+                }
+                if character == "└" {
+                    removing = true
+                }
+            }
+        }
         return String(string.joined(separator: "\n"))
         // O(nlogn + n^2) = O(n^2)
     }

--- a/Learning/Data Structures/Trees/AnyBinaryTree.swift
+++ b/Learning/Data Structures/Trees/AnyBinaryTree.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 Artem Zhukov. All rights reserved.
 //
 
+// MARK: - Node
 protocol BinaryTreeNodePr {
     associatedtype T
     associatedtype Node = Self
@@ -16,6 +17,7 @@ protocol BinaryTreeNodePr {
     //init(_ value: T)
 }
 
+// MARK: - Tree
 enum TraversalOrder {
     /// Pre-order traversal first traverses the root, then the left subtree, and then the right subtree.
     case preOrder
@@ -90,6 +92,7 @@ extension BinaryTreePr {
     }
 }
 
+// MARK: - Miscellaneous
 func clean(string: inout [[Character]]) {
     var maxLineLength = 0
     for line in 0..<string.count {  // indent all lines (for a e s t h e t i c s) O(n^2)
@@ -124,6 +127,44 @@ func clean(string: inout [[Character]]) {
             if character == "└" {
                 removing = true
             }
+        }
+    }
+}
+
+protocol StringConvertibleBinaryTree: CustomStringConvertible where Self: BinaryTreeNodePr, Self.T: CustomStringConvertible {
+}
+extension StringConvertibleBinaryTree {
+    /// A horizontal textual representation of the binary search tree.
+    //    ///
+    //    /// Accessing the property directly is not advised. Apple recommends to use the `String(describing:)` initializer instead. You can also pass the tree object to the `print` function.
+    //    ///
+    //    ///     let tree = BinarySearchTree<Character>("p", "h", "g", "j", "r", "v", "q", "k")
+    //    ///     print(tree)
+    //    ///     // Prints:
+    //    ///     //           ┌─── v
+    //    ///     //      ┌─── r
+    //    ///     //      │    └─── q
+    //    ///     // ──── p
+    //    ///     //      │         ┌─── k
+    //    ///     //      │    ┌─── j
+    //    ///     //      └─── h
+    //    ///     //           └─── g
+    //    ///
+    //    /// The right child in this diagram is always above its parent, and the left child is always below.
+    //    ///
+    //    /// - Complexity: O(*n*^2)
+    var description: String {
+        var string: [[Character]] = []
+        constructString(self, &string, 0) // O(nlogn)
+        clean(string: &string)
+        return String(string.joined(separator: "\n"))
+        // O(nlogn + n^2) = O(n^2)
+    }
+    private func constructString(_ node: Self?, _ str: inout [[Character]], _ indentDepth: Int, _ indent: String = "") { // O(nlogn)
+        if let node = node {
+            constructString(node.rightChild as? Self, &str, indentDepth+1, ((indentDepth != 0) ? String(repeating: "│    ", count: indentDepth) : "") + "┌─── ")
+            str += [Array<Character>(indent + node.value.description)] // O(log n)
+            constructString(node.leftChild as? Self, &str,  indentDepth+1, ((indentDepth != 0) ? String(repeating: "│    ", count: indentDepth) : "") + "└─── ")
         }
     }
 }

--- a/Learning/Data Structures/Trees/AnyBinaryTree.swift
+++ b/Learning/Data Structures/Trees/AnyBinaryTree.swift
@@ -89,3 +89,41 @@ extension BinaryTreePr {
         }
     }
 }
+
+func clean(string: inout [[Character]]) {
+    var maxLineLength = 0
+    for line in 0..<string.count {  // indent all lines (for a e s t h e t i c s) O(n^2)
+        let first = string[line][0]
+        if first != "│" && first != "┌" && first != "└" {
+            string[line] = "──── " + string[line] // O(n)
+        } else {
+            string[line] = "     " + string[line] // O(n)
+        }
+        maxLineLength = max(maxLineLength, string[line].count)
+    }
+    for col in stride(from: 0, to: maxLineLength, by: 5) { // O(n^2)
+        var removing = true
+        for row in 0..<string.count {
+            if col >= string[row].count {
+                removing = true
+                continue
+            }
+            let character = string[row][col]
+            if col > 0 && character != "│" && character != "┌" && character != "└" && string[row][col-1] != " " {
+                removing = true
+                continue
+            }
+            if character == "┌" {
+                removing = false
+            }
+            if removing && character == "│" {
+                string[row][col] = " "
+            } else if removing {
+                removing = false
+            }
+            if character == "└" {
+                removing = true
+            }
+        }
+    }
+}

--- a/Learning/Data Structures/Trees/AnyBinaryTree.swift
+++ b/Learning/Data Structures/Trees/AnyBinaryTree.swift
@@ -7,28 +7,19 @@
 //
 
 // MARK: - Node
-protocol BinaryTreeNodePr {
+protocol AnyBinaryTreeNode {
     associatedtype T
     associatedtype Node = Self
     var value: T { get set }
     var leftChild: Node? { get set }
     var rightChild: Node? { get set }
     var parent: Node? { get set }
-    //init(_ value: T)
 }
 
 // MARK: - Tree
-enum TraversalOrder {
-    /// Pre-order traversal first traverses the root, then the left subtree, and then the right subtree.
-    case preOrder
-    /// In-order traversal first traverses the left subtree, then the root, and then the right subtree.
-    case inOrder
-    /// Post-order traversal first traverses the left subtree, then the right subtree, and then the root.
-    case postOrder
-}
-protocol BinaryTreePr {
+protocol AnyBinaryTree {
     associatedtype T
-    associatedtype Node where Node: BinaryTreeNodePr
+    associatedtype Node where Node: AnyBinaryTreeNode
     //associatedtype TraversalOrder
     var root: Node? { get }
     var count: Int { get }
@@ -38,7 +29,7 @@ protocol BinaryTreePr {
     var postOrderTraversal: [T] { get }
     func traverse(_ order: TraversalOrder, action: (T) -> ())
 }
-extension BinaryTreePr {
+extension AnyBinaryTree {
     var isEmpty: Bool {
         return count == 0
     }
@@ -58,7 +49,7 @@ extension BinaryTreePr {
         return array
     }
 }
-extension BinaryTreePr {
+extension AnyBinaryTree {
     func traverse(_ order: TraversalOrder, action: (T) -> ()) {
         switch order {
             case .preOrder:
@@ -90,6 +81,14 @@ extension BinaryTreePr {
             action(node.value as! T)
         }
     }
+}
+enum TraversalOrder {
+    /// Pre-order traversal first traverses the root, then the left subtree, and then the right subtree.
+    case preOrder
+    /// In-order traversal first traverses the left subtree, then the root, and then the right subtree.
+    case inOrder
+    /// Post-order traversal first traverses the left subtree, then the right subtree, and then the root.
+    case postOrder
 }
 
 // MARK: - Miscellaneous
@@ -131,7 +130,7 @@ func clean(string: inout [[Character]]) {
     }
 }
 
-protocol StringConvertibleBinaryTree: CustomStringConvertible where Self: BinaryTreeNodePr, Self.T: CustomStringConvertible {
+protocol StringConvertibleBinaryTree: CustomStringConvertible where Self: AnyBinaryTreeNode, Self.T: CustomStringConvertible {
 }
 extension StringConvertibleBinaryTree {
     /// A horizontal textual representation of the binary search tree.

--- a/Learning/Data Structures/Trees/AnyBinaryTree.swift
+++ b/Learning/Data Structures/Trees/AnyBinaryTree.swift
@@ -20,7 +20,6 @@ protocol AnyBinaryTreeNode {
 protocol AnyBinaryTree {
     associatedtype T
     associatedtype Node where Node: AnyBinaryTreeNode
-    //associatedtype TraversalOrder
     var root: Node? { get }
     var count: Int { get }
     var isEmpty: Bool { get }
@@ -29,6 +28,7 @@ protocol AnyBinaryTree {
     var postOrderTraversal: [T] { get }
     func traverse(_ order: TraversalOrder, action: (T) -> ())
 }
+// MARK: Property implementations
 extension AnyBinaryTree {
     var isEmpty: Bool {
         return count == 0
@@ -49,6 +49,7 @@ extension AnyBinaryTree {
         return array
     }
 }
+// MARK: Method implementations
 extension AnyBinaryTree {
     func traverse(_ order: TraversalOrder, action: (T) -> ()) {
         switch order {
@@ -91,10 +92,10 @@ enum TraversalOrder {
     case postOrder
 }
 
-// MARK: - Miscellaneous
-protocol StringConvertibleBinaryTree: CustomStringConvertible where Self: AnyBinaryTreeNode, Self.T: CustomStringConvertible {
+// MARK: - Printability
+protocol StringConvertibleBinarySubtree: CustomStringConvertible where Self: AnyBinaryTreeNode, Self.T: CustomStringConvertible {
 }
-extension StringConvertibleBinaryTree {
+extension StringConvertibleBinarySubtree {
     /// A horizontal textual representation of the binary search tree.
     //    ///
     //    /// Accessing the property directly is not advised. Apple recommends to use the `String(describing:)` initializer instead. You can also pass the tree object to the `print` function.

--- a/Learning/Data Structures/Trees/AnyBinaryTree.swift
+++ b/Learning/Data Structures/Trees/AnyBinaryTree.swift
@@ -6,15 +6,15 @@
 //  Copyright © 2020 Artem Zhukov. All rights reserved.
 //
 
-//protocol BinaryTreeNodePr {
-//    associatedtype T
-//    associatedtype Node = Self
-//    var value: T { get set }
-//    var leftChild: Node? { get set }
-//    var rightChild: Node? { get set }
-//    var parent: Node? { get set }
-//    //init(_ value: T)
-//}
+protocol BinaryTreeNodePr {
+    associatedtype T
+    associatedtype Node = Self
+    var value: T { get set }
+    var leftChild: Node? { get set }
+    var rightChild: Node? { get set }
+    var parent: Node? { get set }
+    //init(_ value: T)
+}
 //
 //enum TraversalOrder {
 //    /// Pre-order traversal first traverses the root, then the left subtree, and then the right subtree.

--- a/Learning/Data Structures/Trees/BinarySearchTree.swift
+++ b/Learning/Data Structures/Trees/BinarySearchTree.swift
@@ -146,34 +146,6 @@ class BinarySearchTree<T: Comparable>: BinaryTreePr {
         root?.maximum?.value
     }
     
-    /// An array of objects traversed in-order. For a binary search tree this is also a sorted array of all objects in the tree.
-    ///
-    /// In-order traversal first traverses the left subtree, then the root, and then the right subtree.
-    /// - Complexity: O(*n*)
-//    var inOrderTraversal: [T] {
-//        var array: [T] = []
-//        traverseInOrder(startingWith: root, action: { array.append($0) })
-//        return array
-//    }
-    /// An array of objects traversed pre-order.
-    ///
-    /// Pre-order traversal first traverses the root, then the left subtree, and then the right subtree.
-    /// - Complexity: O(*n*)
-//    var preOrderTraversal: [T] {
-//        var array: [T] = []
-//        traversePreOrder(startingWith: root, action: { array.append($0) })
-//        return array
-//    }
-    /// An array of objects traversed post-order.
-    ///
-    /// Post-order traversal first traverses the left subtree, then the right subtree, and then the root.
-    /// - Complexity: O(*n*)
-//    var postOrderTraversal: [T] {
-//        var array: [T] = []
-//        traversePostOrder(startingWith: root, action: { array.append($0) })
-//        return array
-//    }
-    
     // MARK: Initializers
     
     /// Creates a new, empty binary search tree.
@@ -283,55 +255,6 @@ class BinarySearchTree<T: Comparable>: BinaryTreePr {
     }
     
 }
-
-// MARK: - Traversals
-//extension BinarySearchTree {
-//    /// The order in which the tree is traversed.
-//    enum TraversalOrder {
-//        /// Pre-order traversal first traverses the root, then the left subtree, and then the right subtree.
-//        case preOrder
-//        /// In-order traversal first traverses the left subtree, then the root, and then the right subtree.
-//        case inOrder
-//        /// Post-order traversal first traverses the left subtree, then the right subtree, and then the root.
-//        case postOrder
-//    }
-//    /// Traverses the tree in the specified order and performs an action on its elements. By default, the tree is traversed in-order.
-//    ///
-//    /// - Parameter order: The order in which the tree is traversed. In-order by default.
-//    /// - Parameter action: A closure that accepts an element of the tree and is called on every element during traversal.
-//    /// - Complexity: O(*n*)
-//    func traverse(_ order: TraversalOrder = .inOrder, action: (T) -> ()) {
-//        switch order {
-//            case .preOrder:
-//                traversePreOrder(startingWith: root, action: action)
-//            case .inOrder:
-//                traverseInOrder(startingWith: root, action: action)
-//            case .postOrder:
-//                traversePostOrder(startingWith: root, action: action)
-//        }
-//    }
-//    private func traverseInOrder(startingWith node: Node?, action: (T) -> ()) {
-//        if let node = node {
-//            traverseInOrder(startingWith: node.leftChild, action: action)
-//            action(node.value)
-//            traverseInOrder(startingWith: node.rightChild, action: action)
-//        }
-//    }
-//    private func traversePreOrder(startingWith node: Node?, action: (T) -> ()) {
-//        if let node = node {
-//            action(node.value)
-//            traversePreOrder(startingWith: node.leftChild, action: action)
-//            traversePreOrder(startingWith: node.rightChild, action: action)
-//        }
-//    }
-//    private func traversePostOrder(startingWith node: Node?, action: (T) -> ()) {
-//        if let node = node {
-//            traversePostOrder(startingWith: node.leftChild, action: action)
-//            traversePostOrder(startingWith: node.rightChild, action: action)
-//            action(node.value)
-//        }
-//    }
-//}
 
 // MARK: - Miscellaneous
 extension BinarySearchTreeNode: CustomStringConvertible where T: CustomStringConvertible {

--- a/Learning/Data Structures/Trees/BinarySearchTree.swift
+++ b/Learning/Data Structures/Trees/BinarySearchTree.swift
@@ -125,11 +125,6 @@ class BinarySearchTree<T: Comparable>: BinaryTreePr {
     /// The amount of elements (nodes) in the tree.
     /// - Complexity: O(1)
     private(set) var count = 0
-    /// A Boolean value indicating whether the tree is empty.
-    /// - Complexity: O(1)
-//    var isEmpty: Bool {
-//        return count == 0
-//    }
     
     /// The smallest element in the tree.
     ///
@@ -257,46 +252,6 @@ class BinarySearchTree<T: Comparable>: BinaryTreePr {
 }
 
 // MARK: - Miscellaneous
-//extension BinarySearchTreeNode: CustomStringConvertible where T: CustomStringConvertible {
-//    /// A horizontal textual representation of the binary search tree.
-//    ///
-//    /// Accessing the property directly is not advised. Apple recommends to use the `String(describing:)` initializer instead. You can also pass the tree object to the `print` function.
-//    ///
-//    ///     let tree = BinarySearchTree<Character>("p", "h", "g", "j", "r", "v", "q", "k")
-//    ///     print(tree)
-//    ///     // Prints:
-//    ///     //           ┌─── v
-//    ///     //      ┌─── r
-//    ///     //      │    └─── q
-//    ///     // ──── p
-//    ///     //      │         ┌─── k
-//    ///     //      │    ┌─── j
-//    ///     //      └─── h
-//    ///     //           └─── g
-//    ///
-//    /// The right child in this diagram is always above its parent, and the left child is always below.
-//    ///
-//    /// - Complexity: O(*n*^2)
-//    var description: String {
-//        var string: [[Character]] = []
-//        constructString(&string, 0) // O(nlogn)
-//        clean(string: &string)
-//        return String(string.joined(separator: "\n"))
-//        // O(nlogn + n^2) = O(n^2)
-//    }
-//    private func constructString(_ str: inout [[Character]], _ indentDepth: Int, _ indent: String = "") { // O(nlogn)
-//        rightChild?.constructString(&str, indentDepth+1, ((indentDepth != 0) ? String(repeating: "│    ", count: indentDepth) : "") + "┌─── ")
-//        str += [Array<Character>(indent + self.value.description)] // O(log n)
-//        leftChild?.constructString(&str,  indentDepth+1, ((indentDepth != 0) ? String(repeating: "│    ", count: indentDepth) : "") + "└─── ")
-//    }
-//
-//}
-//extension BinarySearchTree: CustomStringConvertible where T: CustomStringConvertible {
-//    var description: String {
-//        return root?.description ?? "──── nil"
-//    }
-//}
-
 extension BinarySearchTreeNode: CustomStringConvertible where T: CustomStringConvertible {
 }
 extension BinarySearchTreeNode: StringConvertibleBinaryTree where T: CustomStringConvertible {

--- a/Learning/Data Structures/Trees/BinarySearchTree.swift
+++ b/Learning/Data Structures/Trees/BinarySearchTree.swift
@@ -12,7 +12,7 @@
 /// A node in a binary search tree contains a key – a special value according to which the elements are sorted. Therefore the type of the key should conform to `Comparable`. Apart from that, a node keeps links to its left and right child, as well as the parent node.
 ///
 /// You can create a tree yourself just using objects of this class, however you'll have to manage addition and deletion yourself. To avoid that, create a `BinarySearchTree` object. That class is a wrapper for this class and manages addition and deletion.
-class BinarySearchTreeNode<T: Comparable>: BinaryTreeNodePr {
+class BinarySearchTreeNode<T: Comparable>: AnyBinaryTreeNode {
     
     typealias Node = BinarySearchTreeNode<T>
     
@@ -113,7 +113,7 @@ class BinarySearchTreeNode<T: Comparable>: BinaryTreeNodePr {
 /// A binary tree that stores its elements in such a way that all elements smaller than the root are stored in the left subtree, and all elements larger or equal to the root in the right subtree.
 ///
 /// This tree does not rebalance itself, therefore the order in which elements are added is important. If elements are inserted in sorted order, the tree degrades to a doubly linked list.
-class BinarySearchTree<T: Comparable>: BinaryTreePr {
+class BinarySearchTree<T: Comparable>: AnyBinaryTree {
     
     typealias Node = BinarySearchTreeNode<T>
     

--- a/Learning/Data Structures/Trees/BinarySearchTree.swift
+++ b/Learning/Data Structures/Trees/BinarySearchTree.swift
@@ -257,40 +257,51 @@ class BinarySearchTree<T: Comparable>: BinaryTreePr {
 }
 
 // MARK: - Miscellaneous
-extension BinarySearchTreeNode: CustomStringConvertible where T: CustomStringConvertible {
-    /// A horizontal textual representation of the binary search tree.
-    ///
-    /// Accessing the property directly is not advised. Apple recommends to use the `String(describing:)` initializer instead. You can also pass the tree object to the `print` function.
-    ///
-    ///     let tree = BinarySearchTree<Character>("p", "h", "g", "j", "r", "v", "q", "k")
-    ///     print(tree)
-    ///     // Prints:
-    ///     //           ┌─── v
-    ///     //      ┌─── r
-    ///     //      │    └─── q
-    ///     // ──── p
-    ///     //      │         ┌─── k
-    ///     //      │    ┌─── j
-    ///     //      └─── h
-    ///     //           └─── g
-    ///
-    /// The right child in this diagram is always above its parent, and the left child is always below.
-    ///
-    /// - Complexity: O(*n*^2)
-    var description: String {
-        var string: [[Character]] = []
-        constructString(&string, 0) // O(nlogn)
-        clean(string: &string)
-        return String(string.joined(separator: "\n"))
-        // O(nlogn + n^2) = O(n^2)
-    }
-    private func constructString(_ str: inout [[Character]], _ indentDepth: Int, _ indent: String = "") { // O(nlogn)
-        rightChild?.constructString(&str, indentDepth+1, ((indentDepth != 0) ? String(repeating: "│    ", count: indentDepth) : "") + "┌─── ")
-        str += [Array<Character>(indent + self.value.description)] // O(log n)
-        leftChild?.constructString(&str,  indentDepth+1, ((indentDepth != 0) ? String(repeating: "│    ", count: indentDepth) : "") + "└─── ")
-    }
+//extension BinarySearchTreeNode: CustomStringConvertible where T: CustomStringConvertible {
+//    /// A horizontal textual representation of the binary search tree.
+//    ///
+//    /// Accessing the property directly is not advised. Apple recommends to use the `String(describing:)` initializer instead. You can also pass the tree object to the `print` function.
+//    ///
+//    ///     let tree = BinarySearchTree<Character>("p", "h", "g", "j", "r", "v", "q", "k")
+//    ///     print(tree)
+//    ///     // Prints:
+//    ///     //           ┌─── v
+//    ///     //      ┌─── r
+//    ///     //      │    └─── q
+//    ///     // ──── p
+//    ///     //      │         ┌─── k
+//    ///     //      │    ┌─── j
+//    ///     //      └─── h
+//    ///     //           └─── g
+//    ///
+//    /// The right child in this diagram is always above its parent, and the left child is always below.
+//    ///
+//    /// - Complexity: O(*n*^2)
+//    var description: String {
+//        var string: [[Character]] = []
+//        constructString(&string, 0) // O(nlogn)
+//        clean(string: &string)
+//        return String(string.joined(separator: "\n"))
+//        // O(nlogn + n^2) = O(n^2)
+//    }
+//    private func constructString(_ str: inout [[Character]], _ indentDepth: Int, _ indent: String = "") { // O(nlogn)
+//        rightChild?.constructString(&str, indentDepth+1, ((indentDepth != 0) ? String(repeating: "│    ", count: indentDepth) : "") + "┌─── ")
+//        str += [Array<Character>(indent + self.value.description)] // O(log n)
+//        leftChild?.constructString(&str,  indentDepth+1, ((indentDepth != 0) ? String(repeating: "│    ", count: indentDepth) : "") + "└─── ")
+//    }
+//
+//}
+//extension BinarySearchTree: CustomStringConvertible where T: CustomStringConvertible {
+//    var description: String {
+//        return root?.description ?? "──── nil"
+//    }
+//}
 
+extension BinarySearchTreeNode: CustomStringConvertible where T: CustomStringConvertible {
 }
+extension BinarySearchTreeNode: StringConvertibleBinaryTree where T: CustomStringConvertible {
+}
+
 extension BinarySearchTree: CustomStringConvertible where T: CustomStringConvertible {
     var description: String {
         return root?.description ?? "──── nil"

--- a/Learning/Data Structures/Trees/BinarySearchTree.swift
+++ b/Learning/Data Structures/Trees/BinarySearchTree.swift
@@ -12,14 +12,14 @@
 /// A node in a binary search tree contains a key – a special value according to which the elements are sorted. Therefore the type of the key should conform to `Comparable`. Apart from that, a node keeps links to its left and right child, as well as the parent node.
 ///
 /// You can create a tree yourself just using objects of this class, however you'll have to manage addition and deletion yourself. To avoid that, create a `BinarySearchTree` object. That class is a wrapper for this class and manages addition and deletion.
-class BinarySearchTreeNode<T: Comparable> {
+class BinarySearchTreeNode<T: Comparable>: BinaryTreeNodePr {
     
     typealias Node = BinarySearchTreeNode<T>
     
     /// The value according to which the items in the binary search tree are sorted.
     ///
     /// If your type groups several attributes, make it conform to `Comparable` and implement the `<` operator by comparing against the appropriate attribute. This `key` will then contain your entire object, but sorting will be performed by the attribute of your choice.
-    var key: T
+    var value: T
     /// The left child of this node.
     var leftChild: Node?
     /// The right child of this node.
@@ -87,8 +87,8 @@ class BinarySearchTreeNode<T: Comparable> {
     /// Creates a binary search tree node with the given key.
     /// - Parameter key: The key of the node.
     /// - Complexity: O(1)
-    init(_ key: T) {
-        self.key = key
+    init(_ value: T) {
+        self.value = value
     }
     
     /// Looks up and returns the node with the given key in the subtree for which this node is the root.
@@ -97,8 +97,8 @@ class BinarySearchTreeNode<T: Comparable> {
     /// - Complexity: O(log *n*) on average, O(*n*) in worst case.
     func search(for key: T) -> Node? {
         var currentNode: Node? = self
-        while let current = currentNode, current.key != key {
-            if current.key > key {
+        while let current = currentNode, current.value != value {
+            if current.value > value {
                 currentNode = currentNode?.leftChild
             } else {
                 currentNode = currentNode?.rightChild
@@ -113,7 +113,7 @@ class BinarySearchTreeNode<T: Comparable> {
 /// A binary tree that stores its elements in such a way that all elements smaller than the root are stored in the left subtree, and all elements larger or equal to the root in the right subtree.
 ///
 /// This tree does not rebalance itself, therefore the order in which elements are added is important. If elements are inserted in sorted order, the tree degrades to a doubly linked list.
-class BinarySearchTree<T: Comparable> {
+class BinarySearchTree<T: Comparable>: BinaryTreePr {
     
     typealias Node = BinarySearchTreeNode<T>
     
@@ -127,52 +127,52 @@ class BinarySearchTree<T: Comparable> {
     private(set) var count = 0
     /// A Boolean value indicating whether the tree is empty.
     /// - Complexity: O(1)
-    var isEmpty: Bool {
-        return count == 0
-    }
+//    var isEmpty: Bool {
+//        return count == 0
+//    }
     
     /// The smallest element in the tree.
     ///
     /// This element is the leftmost node in the tree.
     /// - Complexity: O(log *n*)
     var minimum: T? {
-        root?.minimum?.key
+        root?.minimum?.value
     }
     /// The largest element in the tree.
     ///
     /// This element is the rightmost node in the tree.
     /// - Complexity: O(log *n*)
     var maximum: T? {
-        root?.maximum?.key
+        root?.maximum?.value
     }
     
     /// An array of objects traversed in-order. For a binary search tree this is also a sorted array of all objects in the tree.
     ///
     /// In-order traversal first traverses the left subtree, then the root, and then the right subtree.
     /// - Complexity: O(*n*)
-    var inOrderTraversal: [T] {
-        var array: [T] = []
-        traverseInOrder(startingWith: root, action: { array.append($0) })
-        return array
-    }
+//    var inOrderTraversal: [T] {
+//        var array: [T] = []
+//        traverseInOrder(startingWith: root, action: { array.append($0) })
+//        return array
+//    }
     /// An array of objects traversed pre-order.
     ///
     /// Pre-order traversal first traverses the root, then the left subtree, and then the right subtree.
     /// - Complexity: O(*n*)
-    var preOrderTraversal: [T] {
-        var array: [T] = []
-        traversePreOrder(startingWith: root, action: { array.append($0) })
-        return array
-    }
+//    var preOrderTraversal: [T] {
+//        var array: [T] = []
+//        traversePreOrder(startingWith: root, action: { array.append($0) })
+//        return array
+//    }
     /// An array of objects traversed post-order.
     ///
     /// Post-order traversal first traverses the left subtree, then the right subtree, and then the root.
     /// - Complexity: O(*n*)
-    var postOrderTraversal: [T] {
-        var array: [T] = []
-        traversePostOrder(startingWith: root, action: { array.append($0) })
-        return array
-    }
+//    var postOrderTraversal: [T] {
+//        var array: [T] = []
+//        traversePostOrder(startingWith: root, action: { array.append($0) })
+//        return array
+//    }
     
     // MARK: Initializers
     
@@ -205,7 +205,7 @@ class BinarySearchTree<T: Comparable> {
         var r: Node? = nil, p = root
         while let pp = p {
             r = p
-            if node.key < pp.key {
+            if node.value < pp.value {
                 p = pp.leftChild
             } else {
                 p = pp.rightChild
@@ -215,7 +215,7 @@ class BinarySearchTree<T: Comparable> {
         node.leftChild = nil
         node.rightChild = nil
         if let rr = r {
-            if node.key < rr.key {
+            if node.value < rr.value {
                 rr.leftChild = node
             } else {
                 rr.rightChild = node
@@ -251,7 +251,7 @@ class BinarySearchTree<T: Comparable> {
             r = node
         } else {
             r = node.successor
-            node.key = r!.key
+            node.value = r!.value
         }
         var p: Node?
         if r?.leftChild != nil {
@@ -285,53 +285,53 @@ class BinarySearchTree<T: Comparable> {
 }
 
 // MARK: - Traversals
-extension BinarySearchTree {
-    /// The order in which the tree is traversed.
-    enum TraversalOrder {
-        /// Pre-order traversal first traverses the root, then the left subtree, and then the right subtree.
-        case preOrder
-        /// In-order traversal first traverses the left subtree, then the root, and then the right subtree.
-        case inOrder
-        /// Post-order traversal first traverses the left subtree, then the right subtree, and then the root.
-        case postOrder
-    }
-    /// Traverses the tree in the specified order and performs an action on its elements. By default, the tree is traversed in-order.
-    ///
-    /// - Parameter order: The order in which the tree is traversed. In-order by default.
-    /// - Parameter action: A closure that accepts an element of the tree and is called on every element during traversal.
-    /// - Complexity: O(*n*)
-    func traverse(_ order: TraversalOrder = .inOrder, action: (T) -> ()) {
-        switch order {
-            case .preOrder:
-                traversePreOrder(startingWith: root, action: action)
-            case .inOrder:
-                traverseInOrder(startingWith: root, action: action)
-            case .postOrder:
-                traversePostOrder(startingWith: root, action: action)
-        }
-    }
-    private func traverseInOrder(startingWith node: Node?, action: (T) -> ()) {
-        if let node = node {
-            traverseInOrder(startingWith: node.leftChild, action: action)
-            action(node.key)
-            traverseInOrder(startingWith: node.rightChild, action: action)
-        }
-    }
-    private func traversePreOrder(startingWith node: Node?, action: (T) -> ()) {
-        if let node = node {
-            action(node.key)
-            traversePreOrder(startingWith: node.leftChild, action: action)
-            traversePreOrder(startingWith: node.rightChild, action: action)
-        }
-    }
-    private func traversePostOrder(startingWith node: Node?, action: (T) -> ()) {
-        if let node = node {
-            traversePostOrder(startingWith: node.leftChild, action: action)
-            traversePostOrder(startingWith: node.rightChild, action: action)
-            action(node.key)
-        }
-    }
-}
+//extension BinarySearchTree {
+//    /// The order in which the tree is traversed.
+//    enum TraversalOrder {
+//        /// Pre-order traversal first traverses the root, then the left subtree, and then the right subtree.
+//        case preOrder
+//        /// In-order traversal first traverses the left subtree, then the root, and then the right subtree.
+//        case inOrder
+//        /// Post-order traversal first traverses the left subtree, then the right subtree, and then the root.
+//        case postOrder
+//    }
+//    /// Traverses the tree in the specified order and performs an action on its elements. By default, the tree is traversed in-order.
+//    ///
+//    /// - Parameter order: The order in which the tree is traversed. In-order by default.
+//    /// - Parameter action: A closure that accepts an element of the tree and is called on every element during traversal.
+//    /// - Complexity: O(*n*)
+//    func traverse(_ order: TraversalOrder = .inOrder, action: (T) -> ()) {
+//        switch order {
+//            case .preOrder:
+//                traversePreOrder(startingWith: root, action: action)
+//            case .inOrder:
+//                traverseInOrder(startingWith: root, action: action)
+//            case .postOrder:
+//                traversePostOrder(startingWith: root, action: action)
+//        }
+//    }
+//    private func traverseInOrder(startingWith node: Node?, action: (T) -> ()) {
+//        if let node = node {
+//            traverseInOrder(startingWith: node.leftChild, action: action)
+//            action(node.value)
+//            traverseInOrder(startingWith: node.rightChild, action: action)
+//        }
+//    }
+//    private func traversePreOrder(startingWith node: Node?, action: (T) -> ()) {
+//        if let node = node {
+//            action(node.value)
+//            traversePreOrder(startingWith: node.leftChild, action: action)
+//            traversePreOrder(startingWith: node.rightChild, action: action)
+//        }
+//    }
+//    private func traversePostOrder(startingWith node: Node?, action: (T) -> ()) {
+//        if let node = node {
+//            traversePostOrder(startingWith: node.leftChild, action: action)
+//            traversePostOrder(startingWith: node.rightChild, action: action)
+//            action(node.value)
+//        }
+//    }
+//}
 
 // MARK: - Miscellaneous
 extension BinarySearchTreeNode: CustomStringConvertible where T: CustomStringConvertible {
@@ -397,7 +397,7 @@ extension BinarySearchTreeNode: CustomStringConvertible where T: CustomStringCon
     }
     private func constructString(_ str: inout [[Character]], _ indentDepth: Int, _ indent: String = "") { // O(nlogn)
         rightChild?.constructString(&str, indentDepth+1, ((indentDepth != 0) ? String(repeating: "│    ", count: indentDepth) : "") + "┌─── ")
-        str += [Array<Character>(indent + self.key.description)] // O(log n)
+        str += [Array<Character>(indent + self.value.description)] // O(log n)
         leftChild?.constructString(&str,  indentDepth+1, ((indentDepth != 0) ? String(repeating: "│    ", count: indentDepth) : "") + "└─── ")
     }
 

--- a/Learning/Data Structures/Trees/BinarySearchTree.swift
+++ b/Learning/Data Structures/Trees/BinarySearchTree.swift
@@ -280,41 +280,7 @@ extension BinarySearchTreeNode: CustomStringConvertible where T: CustomStringCon
     var description: String {
         var string: [[Character]] = []
         constructString(&string, 0) // O(nlogn)
-        var maxLineLength = 0
-        for line in 0..<string.count {  // indent all lines (for a e s t h e t i c s) O(n^2)
-            let first = string[line][0]
-            if first != "│" && first != "┌" && first != "└" {
-                string[line] = "──── " + string[line] // O(n)
-            } else {
-                string[line] = "     " + string[line] // O(n)
-            }
-            maxLineLength = max(maxLineLength, string[line].count)
-        }
-        for col in stride(from: 0, to: maxLineLength, by: 5) { // O(n^2)
-            var removing = true
-            for row in 0..<string.count {
-                if col >= string[row].count {
-                    removing = true
-                    continue
-                }
-                let character = string[row][col]
-                if col > 0 && character != "│" && character != "┌" && character != "└" && string[row][col-1] != " " {
-                    removing = true
-                    continue
-                }
-                if character == "┌" {
-                    removing = false
-                }
-                if removing && character == "│" {
-                    string[row][col] = " "
-                } else if removing {
-                    removing = false
-                }
-                if character == "└" {
-                    removing = true
-                }
-            }
-        }
+        clean(string: &string)
         return String(string.joined(separator: "\n"))
         // O(nlogn + n^2) = O(n^2)
     }

--- a/Learning/Data Structures/Trees/BinarySearchTree.swift
+++ b/Learning/Data Structures/Trees/BinarySearchTree.swift
@@ -12,14 +12,14 @@
 /// A node in a binary search tree contains a key – a special value according to which the elements are sorted. Therefore the type of the key should conform to `Comparable`. Apart from that, a node keeps links to its left and right child, as well as the parent node.
 ///
 /// You can create a tree yourself just using objects of this class, however you'll have to manage addition and deletion yourself. To avoid that, create a `BinarySearchTree` object. That class is a wrapper for this class and manages addition and deletion.
-class BinarySearchTreeNode<T: Comparable>: AnyBinaryTreeNode {
+class BinarySearchTreeNode<Element: Comparable>: AnyBinaryTreeNode {
     
-    typealias Node = BinarySearchTreeNode<T>
+    typealias Node = BinarySearchTreeNode<Element>
     
     /// The value according to which the items in the binary search tree are sorted.
     ///
     /// If your type groups several attributes, make it conform to `Comparable` and implement the `<` operator by comparing against the appropriate attribute. This `key` will then contain your entire object, but sorting will be performed by the attribute of your choice.
-    var value: T
+    var value: Element
     /// The left child of this node.
     var leftChild: Node?
     /// The right child of this node.
@@ -87,7 +87,7 @@ class BinarySearchTreeNode<T: Comparable>: AnyBinaryTreeNode {
     /// Creates a binary search tree node with the given key.
     /// - Parameter key: The key of the node.
     /// - Complexity: O(1)
-    init(_ value: T) {
+    init(_ value: Element) {
         self.value = value
     }
     
@@ -95,7 +95,7 @@ class BinarySearchTreeNode<T: Comparable>: AnyBinaryTreeNode {
     /// - Parameter key: The key to be found.
     /// - Returns: The node with the specified key or `nil` if it's not present.
     /// - Complexity: O(log *n*) on average, O(*n*) in worst case.
-    func search(for key: T) -> Node? {
+    func search(for key: Element) -> Node? {
         var currentNode: Node? = self
         while let current = currentNode, current.value != value {
             if current.value > value {
@@ -113,9 +113,9 @@ class BinarySearchTreeNode<T: Comparable>: AnyBinaryTreeNode {
 /// A binary tree that stores its elements in such a way that all elements smaller than the root are stored in the left subtree, and all elements larger or equal to the root in the right subtree.
 ///
 /// This tree does not rebalance itself, therefore the order in which elements are added is important. If elements are inserted in sorted order, the tree degrades to a doubly linked list.
-class BinarySearchTree<T: Comparable>: AnyBinaryTree {
+class BinarySearchTree<Element: Comparable>: AnyBinaryTree {
     
-    typealias Node = BinarySearchTreeNode<T>
+    typealias Node = BinarySearchTreeNode<Element>
     
     // MARK: Properties
     
@@ -130,14 +130,14 @@ class BinarySearchTree<T: Comparable>: AnyBinaryTree {
     ///
     /// This element is the leftmost node in the tree.
     /// - Complexity: O(log *n*)
-    var minimum: T? {
+    var minimum: Element? {
         root?.minimum?.value
     }
     /// The largest element in the tree.
     ///
     /// This element is the rightmost node in the tree.
     /// - Complexity: O(log *n*)
-    var maximum: T? {
+    var maximum: Element? {
         root?.maximum?.value
     }
     
@@ -150,7 +150,7 @@ class BinarySearchTree<T: Comparable>: AnyBinaryTree {
     
     /// Creates a new binary search tree and inserts elements from the array (in the respective order) into it.
     /// - Complexity: O(*n* log *n*) on average, O(*n*^2) in worst case.
-    init(_ array: [T]) {
+    init(_ array: [Element]) {
         for element in array {
             add(element)
         }
@@ -158,7 +158,7 @@ class BinarySearchTree<T: Comparable>: AnyBinaryTree {
     
     /// Creates a new binary search tree and inserts elements that are passed to the initializer in the same order into the tree.
     /// - Complexity: O(*n* log *n*) on average, O(*n*^2) in worst case.
-    convenience init(_ items: T...) {
+    convenience init(_ items: Element...) {
         self.init(items)
     }
     
@@ -196,7 +196,7 @@ class BinarySearchTree<T: Comparable>: AnyBinaryTree {
     ///
     /// - Parameter key: The element to be inserted.
     /// - Complexity: O(log *n*) on average, O(*n*) in worst case.
-    func add(_ key: T) {
+    func add(_ key: Element) {
         let node = Node(key)
         add(node)
     }
@@ -205,7 +205,7 @@ class BinarySearchTree<T: Comparable>: AnyBinaryTree {
     /// - Parameter key: The key to be found.
     /// - Returns: The node with the specified key or `nil` if it's not present.
     /// - Complexity: O(log *n*) on average, O(*n*) in worst case.
-    func search(_ key: T) -> Node? {
+    func search(_ key: Element) -> Node? {
         root?.search(for: key)
     }
     
@@ -243,7 +243,7 @@ class BinarySearchTree<T: Comparable>: AnyBinaryTree {
     /// Removes an element from the tree.
     /// - Parameter node: The element to be removed from the tree.
     /// - Complexity: O(log *n*) on average, O(*n*) in worst case.
-    func remove(_ key: T) {
+    func remove(_ key: Element) {
         let node = search(key)
         assert(node != nil, "The key to be removed is not present in the tree")
         remove(node!)
@@ -252,12 +252,12 @@ class BinarySearchTree<T: Comparable>: AnyBinaryTree {
 }
 
 // MARK: - Miscellaneous
-extension BinarySearchTreeNode: CustomStringConvertible where T: CustomStringConvertible {
+extension BinarySearchTreeNode: CustomStringConvertible where Element: CustomStringConvertible {
 }
-extension BinarySearchTreeNode: StringConvertibleBinarySubtree where T: CustomStringConvertible {
+extension BinarySearchTreeNode: StringConvertibleBinarySubtree where Element: CustomStringConvertible {
 }
 
-extension BinarySearchTree: CustomStringConvertible where T: CustomStringConvertible {
+extension BinarySearchTree: CustomStringConvertible where Element: CustomStringConvertible {
     var description: String {
         return root?.description ?? "──── nil"
     }

--- a/Learning/Data Structures/Trees/BinarySearchTree.swift
+++ b/Learning/Data Structures/Trees/BinarySearchTree.swift
@@ -254,7 +254,7 @@ class BinarySearchTree<T: Comparable>: AnyBinaryTree {
 // MARK: - Miscellaneous
 extension BinarySearchTreeNode: CustomStringConvertible where T: CustomStringConvertible {
 }
-extension BinarySearchTreeNode: StringConvertibleBinaryTree where T: CustomStringConvertible {
+extension BinarySearchTreeNode: StringConvertibleBinarySubtree where T: CustomStringConvertible {
 }
 
 extension BinarySearchTree: CustomStringConvertible where T: CustomStringConvertible {

--- a/Learning/Data Structures/Trees/BinaryTree.swift
+++ b/Learning/Data Structures/Trees/BinaryTree.swift
@@ -6,16 +6,6 @@
 //  Copyright © 2020 Artem Zhukov. All rights reserved.
 //
 
-//protocol BinaryTreeNodePr {
-//    associatedtype T
-//    associatedtype Node = Self
-//    var value: T { get set }
-//    var leftChild: Node? { get set }
-//    var rightChild: Node? { get set }
-//    var parent: Node? { get set }
-//    //init(_ value: T)
-//}
-
 // MARK: - Node
 class BinaryTreeNode<T>: BinaryTreeNodePr {
     
@@ -38,80 +28,6 @@ class BinaryTreeNode<T>: BinaryTreeNodePr {
     }
     
 }
-
-//enum TraversalOrder {
-//    /// Pre-order traversal first traverses the root, then the left subtree, and then the right subtree.
-//    case preOrder
-//    /// In-order traversal first traverses the left subtree, then the root, and then the right subtree.
-//    case inOrder
-//    /// Post-order traversal first traverses the left subtree, then the right subtree, and then the root.
-//    case postOrder
-//}
-//protocol BinaryTreePr {
-//    associatedtype T
-//    associatedtype Node where Node: BinaryTreeNodePr
-//    //associatedtype TraversalOrder
-//    var root: Node? { get }
-//    var count: Int { get }
-//    var isEmpty: Bool { get }
-//    var inOrderTraversal: [T] { get }
-//    var preOrderTraversal: [T] { get }
-//    var postOrderTraversal: [T] { get }
-//    func traverse(_ order: TraversalOrder, action: (T) -> ())
-//}
-//extension BinaryTreePr {
-//    var isEmpty: Bool {
-//        return count == 0
-//    }
-//    var inOrderTraversal: [T] {
-//        var array: [T] = []
-//        traverseInOrder(startingWith: root, action: { array.append($0) })
-//        return array
-//    }
-//    var preOrderTraversal: [T] {
-//        var array: [T] = []
-//        traversePreOrder(startingWith: root, action: { array.append($0) })
-//        return array
-//    }
-//    var postOrderTraversal: [T] {
-//        var array: [T] = []
-//        traversePostOrder(startingWith: root, action: { array.append($0) })
-//        return array
-//    }
-//}
-//extension BinaryTreePr {
-//    func traverse(_ order: TraversalOrder, action: (T) -> ()) {
-//        switch order {
-//            case .preOrder:
-//                traversePreOrder(startingWith: root, action: action)
-//            case .inOrder:
-//                traverseInOrder(startingWith: root, action: action)
-//            case .postOrder:
-//                traversePostOrder(startingWith: root, action: action)
-//        }
-//    }
-//    private func traverseInOrder(startingWith node: Node?, action: (T) -> ()) {
-//        if let node = node {
-//            traverseInOrder(startingWith: node.leftChild as? Node, action: action)
-//            action(node.value as! T)
-//            traverseInOrder(startingWith: node.rightChild as? Node, action: action)
-//        }
-//    }
-//    private func traversePreOrder(startingWith node: Node?, action: (T) -> ()) {
-//        if let node = node {
-//            action(node.value as! T)
-//            traversePreOrder(startingWith: node.leftChild as? Node, action: action)
-//            traversePreOrder(startingWith: node.rightChild as? Node, action: action)
-//        }
-//    }
-//    private func traversePostOrder(startingWith node: Node?, action: (T) -> ()) {
-//        if let node = node {
-//            traversePostOrder(startingWith: node.leftChild as? Node, action: action)
-//            traversePostOrder(startingWith: node.rightChild as? Node, action: action)
-//            action(node.value as! T)
-//        }
-//    }
-//}
 
 // MARK: - Tree
 class BinaryTree<T>: BinaryTreePr {

--- a/Learning/Data Structures/Trees/BinaryTree.swift
+++ b/Learning/Data Structures/Trees/BinaryTree.swift
@@ -7,30 +7,32 @@
 //
 
 // MARK: - Node
-class BinaryTreeNode<T>: AnyBinaryTreeNode {
+class BinaryTreeNode<Element>: AnyBinaryTreeNode {
+    
+    typealias Node = BinaryTreeNode<Element>
         
     /// The value of the node.
-    var value: T
+    var value: Element
     /// The left child of the node.
-    var leftChild: BinaryTreeNode<T>?
+    var leftChild: Node?
     /// The right child of the node.
-    var rightChild: BinaryTreeNode<T>?
+    var rightChild: Node?
     /// The parent node of the node.
-    weak var parent: BinaryTreeNode<T>?
+    weak var parent: Node?
     
     /// Creates a node with the given value.
     /// - Parameter key: The value of the node.
     /// - Complexity: O(1)
-    init(_ value: T) {
+    init(_ value: Element) {
         self.value = value
     }
     
 }
 
 // MARK: - Tree
-class BinaryTree<T>: AnyBinaryTree {
+class BinaryTree<Element>: AnyBinaryTree {
     
-    typealias Node = BinaryTreeNode<T>
+    typealias Node = BinaryTreeNode<Element>
     
     // MARK: Properties
     
@@ -60,10 +62,10 @@ class BinaryTree<T>: AnyBinaryTree {
     
 }
 
-extension BinaryTreeNode: StringConvertibleBinarySubtree where T: CustomStringConvertible {}
-extension BinaryTreeNode: CustomStringConvertible where T: CustomStringConvertible {}
+extension BinaryTreeNode: StringConvertibleBinarySubtree where Element: CustomStringConvertible {}
+extension BinaryTreeNode: CustomStringConvertible where Element: CustomStringConvertible {}
 
-extension BinaryTree: CustomStringConvertible where T: CustomStringConvertible {
+extension BinaryTree: CustomStringConvertible where Element: CustomStringConvertible {
     var description: String {
         return root?.description ?? "──── nil"
     }

--- a/Learning/Data Structures/Trees/BinaryTree.swift
+++ b/Learning/Data Structures/Trees/BinaryTree.swift
@@ -62,47 +62,6 @@ class BinaryTree<T>: BinaryTreePr {
     
 }
 
-// MARK: - Miscellaneous
-//extension BinaryTreeNode: CustomStringConvertible where T: CustomStringConvertible {
-//    /// A horizontal textual representation of the binary search tree.
-//    ///
-//    /// Accessing the property directly is not advised. Apple recommends to use the `String(describing:)` initializer instead. You can also pass the tree object to the `print` function.
-//    ///
-//    ///     let tree = BinarySearchTree<Character>("p", "h", "g", "j", "r", "v", "q", "k")
-//    ///     print(tree)
-//    ///     // Prints:
-//    ///     //           ┌─── v
-//    ///     //      ┌─── r
-//    ///     //      │    └─── q
-//    ///     // ──── p
-//    ///     //      │         ┌─── k
-//    ///     //      │    ┌─── j
-//    ///     //      └─── h
-//    ///     //           └─── g
-//    ///
-//    /// The right child in this diagram is always above its parent, and the left child is always below.
-//    ///
-//    /// - Complexity: O(*n*^2)
-//    var description: String {
-//        var string: [[Character]] = []
-//        constructString(&string, 0) // O(nlogn)
-//        clean(string: &string)
-//        return String(string.joined(separator: "\n"))
-//        // O(nlogn + n^2) = O(n^2)
-//    }
-//    private func constructString(_ str: inout [[Character]], _ indentDepth: Int, _ indent: String = "") { // O(nlogn)
-//        rightChild?.constructString(&str, indentDepth+1, ((indentDepth != 0) ? String(repeating: "│    ", count: indentDepth) : "") + "┌─── ")
-//        str += [Array<Character>(indent + self.value.description)] // O(log n)
-//        leftChild?.constructString(&str,  indentDepth+1, ((indentDepth != 0) ? String(repeating: "│    ", count: indentDepth) : "") + "└─── ")
-//    }
-//
-//}
-//extension BinaryTree: CustomStringConvertible where T: CustomStringConvertible {
-//    var description: String {
-//        return root?.description ?? "──── nil"
-//    }
-//}
-
 extension BinaryTreeNode: StringConvertibleBinaryTree where T: CustomStringConvertible {}
 extension BinaryTreeNode: CustomStringConvertible where T: CustomStringConvertible {}
 

--- a/Learning/Data Structures/Trees/BinaryTree.swift
+++ b/Learning/Data Structures/Trees/BinaryTree.swift
@@ -63,40 +63,49 @@ class BinaryTree<T>: BinaryTreePr {
 }
 
 // MARK: - Miscellaneous
-extension BinaryTreeNode: CustomStringConvertible where T: CustomStringConvertible {
-    /// A horizontal textual representation of the binary search tree.
-    ///
-    /// Accessing the property directly is not advised. Apple recommends to use the `String(describing:)` initializer instead. You can also pass the tree object to the `print` function.
-    ///
-    ///     let tree = BinarySearchTree<Character>("p", "h", "g", "j", "r", "v", "q", "k")
-    ///     print(tree)
-    ///     // Prints:
-    ///     //           ┌─── v
-    ///     //      ┌─── r
-    ///     //      │    └─── q
-    ///     // ──── p
-    ///     //      │         ┌─── k
-    ///     //      │    ┌─── j
-    ///     //      └─── h
-    ///     //           └─── g
-    ///
-    /// The right child in this diagram is always above its parent, and the left child is always below.
-    ///
-    /// - Complexity: O(*n*^2)
-    var description: String {
-        var string: [[Character]] = []
-        constructString(&string, 0) // O(nlogn)
-        clean(string: &string)
-        return String(string.joined(separator: "\n"))
-        // O(nlogn + n^2) = O(n^2)
-    }
-    private func constructString(_ str: inout [[Character]], _ indentDepth: Int, _ indent: String = "") { // O(nlogn)
-        rightChild?.constructString(&str, indentDepth+1, ((indentDepth != 0) ? String(repeating: "│    ", count: indentDepth) : "") + "┌─── ")
-        str += [Array<Character>(indent + self.value.description)] // O(log n)
-        leftChild?.constructString(&str,  indentDepth+1, ((indentDepth != 0) ? String(repeating: "│    ", count: indentDepth) : "") + "└─── ")
-    }
+//extension BinaryTreeNode: CustomStringConvertible where T: CustomStringConvertible {
+//    /// A horizontal textual representation of the binary search tree.
+//    ///
+//    /// Accessing the property directly is not advised. Apple recommends to use the `String(describing:)` initializer instead. You can also pass the tree object to the `print` function.
+//    ///
+//    ///     let tree = BinarySearchTree<Character>("p", "h", "g", "j", "r", "v", "q", "k")
+//    ///     print(tree)
+//    ///     // Prints:
+//    ///     //           ┌─── v
+//    ///     //      ┌─── r
+//    ///     //      │    └─── q
+//    ///     // ──── p
+//    ///     //      │         ┌─── k
+//    ///     //      │    ┌─── j
+//    ///     //      └─── h
+//    ///     //           └─── g
+//    ///
+//    /// The right child in this diagram is always above its parent, and the left child is always below.
+//    ///
+//    /// - Complexity: O(*n*^2)
+//    var description: String {
+//        var string: [[Character]] = []
+//        constructString(&string, 0) // O(nlogn)
+//        clean(string: &string)
+//        return String(string.joined(separator: "\n"))
+//        // O(nlogn + n^2) = O(n^2)
+//    }
+//    private func constructString(_ str: inout [[Character]], _ indentDepth: Int, _ indent: String = "") { // O(nlogn)
+//        rightChild?.constructString(&str, indentDepth+1, ((indentDepth != 0) ? String(repeating: "│    ", count: indentDepth) : "") + "┌─── ")
+//        str += [Array<Character>(indent + self.value.description)] // O(log n)
+//        leftChild?.constructString(&str,  indentDepth+1, ((indentDepth != 0) ? String(repeating: "│    ", count: indentDepth) : "") + "└─── ")
+//    }
+//
+//}
+//extension BinaryTree: CustomStringConvertible where T: CustomStringConvertible {
+//    var description: String {
+//        return root?.description ?? "──── nil"
+//    }
+//}
 
-}
+extension BinaryTreeNode: StringConvertibleBinaryTree where T: CustomStringConvertible {}
+extension BinaryTreeNode: CustomStringConvertible where T: CustomStringConvertible {}
+
 extension BinaryTree: CustomStringConvertible where T: CustomStringConvertible {
     var description: String {
         return root?.description ?? "──── nil"

--- a/Learning/Data Structures/Trees/BinaryTree.swift
+++ b/Learning/Data Structures/Trees/BinaryTree.swift
@@ -39,6 +39,65 @@ class BinaryTreeNode<T>: BinaryTreeNodePr {
     
 }
 
+enum TraversalOrder {
+    /// Pre-order traversal first traverses the root, then the left subtree, and then the right subtree.
+    case preOrder
+    /// In-order traversal first traverses the left subtree, then the root, and then the right subtree.
+    case inOrder
+    /// Post-order traversal first traverses the left subtree, then the right subtree, and then the root.
+    case postOrder
+}
+protocol BinaryTreePr {
+    associatedtype T
+    associatedtype Node where Node: BinaryTreeNodePr
+    //associatedtype TraversalOrder
+    var root: Node? { get }
+    var count: Int { get }
+    var isEmpty: Bool { get }
+    var inOrderTraversal: [T] { get }
+    var preOrderTraversal: [T] { get }
+    var postOrderTraversal: [T] { get }
+    func traverse(_ order: TraversalOrder, action: (T) -> ())
+}
+extension BinaryTreePr {
+    var isEmpty: Bool {
+        return count == 0
+    }
+}
+extension BinaryTreePr {
+    func traverse(_ order: TraversalOrder, action: (T) -> ()) {
+        switch order {
+            case .preOrder:
+                traversePreOrder(startingWith: root, action: action)
+            case .inOrder:
+                traverseInOrder(startingWith: root, action: action)
+            case .postOrder:
+                traversePostOrder(startingWith: root, action: action)
+        }
+    }
+    private func traverseInOrder(startingWith node: Node?, action: (T) -> ()) {
+        if let node = node {
+            traverseInOrder(startingWith: node.leftChild as? Node, action: action)
+            action(node.value as! T)
+            traverseInOrder(startingWith: node.rightChild as? Node, action: action)
+        }
+    }
+    private func traversePreOrder(startingWith node: Node?, action: (T) -> ()) {
+        if let node = node {
+            action(node.value as! T)
+            traversePreOrder(startingWith: node.leftChild as? Node, action: action)
+            traversePreOrder(startingWith: node.rightChild as? Node, action: action)
+        }
+    }
+    private func traversePostOrder(startingWith node: Node?, action: (T) -> ()) {
+        if let node = node {
+            traversePostOrder(startingWith: node.leftChild as? Node, action: action)
+            traversePostOrder(startingWith: node.rightChild as? Node, action: action)
+            action(node.value as! T)
+        }
+    }
+}
+
 // MARK: - Tree
 class BinaryTree<T: Comparable> {
     

--- a/Learning/Data Structures/Trees/BinaryTree.swift
+++ b/Learning/Data Structures/Trees/BinaryTree.swift
@@ -63,6 +63,21 @@ extension BinaryTreePr {
     var isEmpty: Bool {
         return count == 0
     }
+    var inOrderTraversal: [T] {
+        var array: [T] = []
+        traverseInOrder(startingWith: root, action: { array.append($0) })
+        return array
+    }
+    var preOrderTraversal: [T] {
+        var array: [T] = []
+        traversePreOrder(startingWith: root, action: { array.append($0) })
+        return array
+    }
+    var postOrderTraversal: [T] {
+        var array: [T] = []
+        traversePostOrder(startingWith: root, action: { array.append($0) })
+        return array
+    }
 }
 extension BinaryTreePr {
     func traverse(_ order: TraversalOrder, action: (T) -> ()) {
@@ -99,7 +114,7 @@ extension BinaryTreePr {
 }
 
 // MARK: - Tree
-class BinaryTree<T: Comparable> {
+class BinaryTree<T>: BinaryTreePr {
     
     typealias Node = BinaryTreeNode<T>
     
@@ -113,37 +128,37 @@ class BinaryTree<T: Comparable> {
     private(set) var count = 0
     /// A Boolean value indicating whether the binary tree is empty.
     /// - Complexity: O(1)
-    var isEmpty: Bool {
-        return count == 0
-    }
+//    var isEmpty: Bool {
+//        return count == 0
+//    }
     
     /// An array of objects traversed in-order.
     ///
     /// In-order traversal first traverses the left subtree, then the root, and then the right subtree.
     /// - Complexity: O(*n*)
-    var inOrderTraversal: [T] {
-        var array: [T] = []
-        traverseInOrder(startingWith: root, action: { array.append($0) })
-        return array
-    }
+//    var inOrderTraversal: [T] {
+//        var array: [T] = []
+//        traverseInOrder(startingWith: root, action: { array.append($0) })
+//        return array
+//    }
     /// An array of objects traversed pre-order.
     ///
     /// Pre-order traversal first traverses the root, then the left subtree, and then the right subtree.
     /// - Complexity: O(*n*)
-    var preOrderTraversal: [T] {
-        var array: [T] = []
-        traversePreOrder(startingWith: root, action: { array.append($0) })
-        return array
-    }
+//    var preOrderTraversal: [T] {
+//        var array: [T] = []
+//        traversePreOrder(startingWith: root, action: { array.append($0) })
+//        return array
+//    }
     /// An array of objects traversed post-order.
     ///
     /// Post-order traversal first traverses the left subtree, then the right subtree, and then the root.
     /// - Complexity: O(*n*)
-    var postOrderTraversal: [T] {
-        var array: [T] = []
-        traversePostOrder(startingWith: root, action: { array.append($0) })
-        return array
-    }
+//    var postOrderTraversal: [T] {
+//        var array: [T] = []
+//        traversePostOrder(startingWith: root, action: { array.append($0) })
+//        return array
+//    }
     
     // MARK: - Initializers
     
@@ -163,53 +178,53 @@ class BinaryTree<T: Comparable> {
 }
 
 // MARK: - Traversals
-extension BinaryTree {
-    /// The order in which the tree is traversed.
-    enum TraversalOrder {
-        /// Pre-order traversal first traverses the root, then the left subtree, and then the right subtree.
-        case preOrder
-        /// In-order traversal first traverses the left subtree, then the root, and then the right subtree.
-        case inOrder
-        /// Post-order traversal first traverses the left subtree, then the right subtree, and then the root.
-        case postOrder
-    }
-    /// Traverses the tree in the specified order and performs an action on its elements. By default, the tree is traversed in-order.
-    ///
-    /// - Parameter order: The order in which the tree is traversed. In-order by default.
-    /// - Parameter action: A closure that accepts an element of the tree and is called on every element during traversal.
-    /// - Complexity: O(*n*)
-    func traverse(_ order: TraversalOrder = .inOrder, action: (T) -> ()) {
-        switch order {
-            case .preOrder:
-                traversePreOrder(startingWith: root, action: action)
-            case .inOrder:
-                traverseInOrder(startingWith: root, action: action)
-            case .postOrder:
-                traversePostOrder(startingWith: root, action: action)
-        }
-    }
-    private func traverseInOrder(startingWith node: Node?, action: (T) -> ()) {
-        if let node = node {
-            traverseInOrder(startingWith: node.leftChild, action: action)
-            action(node.value)
-            traverseInOrder(startingWith: node.rightChild, action: action)
-        }
-    }
-    private func traversePreOrder(startingWith node: Node?, action: (T) -> ()) {
-        if let node = node {
-            action(node.value)
-            traversePreOrder(startingWith: node.leftChild, action: action)
-            traversePreOrder(startingWith: node.rightChild, action: action)
-        }
-    }
-    private func traversePostOrder(startingWith node: Node?, action: (T) -> ()) {
-        if let node = node {
-            traversePostOrder(startingWith: node.leftChild, action: action)
-            traversePostOrder(startingWith: node.rightChild, action: action)
-            action(node.value)
-        }
-    }
-}
+//extension BinaryTree {
+//    /// The order in which the tree is traversed.
+//    enum TraversalOrder {
+//        /// Pre-order traversal first traverses the root, then the left subtree, and then the right subtree.
+//        case preOrder
+//        /// In-order traversal first traverses the left subtree, then the root, and then the right subtree.
+//        case inOrder
+//        /// Post-order traversal first traverses the left subtree, then the right subtree, and then the root.
+//        case postOrder
+//    }
+//    /// Traverses the tree in the specified order and performs an action on its elements. By default, the tree is traversed in-order.
+//    ///
+//    /// - Parameter order: The order in which the tree is traversed. In-order by default.
+//    /// - Parameter action: A closure that accepts an element of the tree and is called on every element during traversal.
+//    /// - Complexity: O(*n*)
+//    func traverse(_ order: TraversalOrder = .inOrder, action: (T) -> ()) {
+//        switch order {
+//            case .preOrder:
+//                traversePreOrder(startingWith: root, action: action)
+//            case .inOrder:
+//                traverseInOrder(startingWith: root, action: action)
+//            case .postOrder:
+//                traversePostOrder(startingWith: root, action: action)
+//        }
+//    }
+//    private func traverseInOrder(startingWith node: Node?, action: (T) -> ()) {
+//        if let node = node {
+//            traverseInOrder(startingWith: node.leftChild, action: action)
+//            action(node.value)
+//            traverseInOrder(startingWith: node.rightChild, action: action)
+//        }
+//    }
+//    private func traversePreOrder(startingWith node: Node?, action: (T) -> ()) {
+//        if let node = node {
+//            action(node.value)
+//            traversePreOrder(startingWith: node.leftChild, action: action)
+//            traversePreOrder(startingWith: node.rightChild, action: action)
+//        }
+//    }
+//    private func traversePostOrder(startingWith node: Node?, action: (T) -> ()) {
+//        if let node = node {
+//            traversePostOrder(startingWith: node.leftChild, action: action)
+//            traversePostOrder(startingWith: node.rightChild, action: action)
+//            action(node.value)
+//        }
+//    }
+//}
 
 // MARK: - Miscellaneous
 extension BinaryTreeNode: CustomStringConvertible where T: CustomStringConvertible {

--- a/Learning/Data Structures/Trees/BinaryTree.swift
+++ b/Learning/Data Structures/Trees/BinaryTree.swift
@@ -39,79 +39,79 @@ class BinaryTreeNode<T>: BinaryTreeNodePr {
     
 }
 
-enum TraversalOrder {
-    /// Pre-order traversal first traverses the root, then the left subtree, and then the right subtree.
-    case preOrder
-    /// In-order traversal first traverses the left subtree, then the root, and then the right subtree.
-    case inOrder
-    /// Post-order traversal first traverses the left subtree, then the right subtree, and then the root.
-    case postOrder
-}
-protocol BinaryTreePr {
-    associatedtype T
-    associatedtype Node where Node: BinaryTreeNodePr
-    //associatedtype TraversalOrder
-    var root: Node? { get }
-    var count: Int { get }
-    var isEmpty: Bool { get }
-    var inOrderTraversal: [T] { get }
-    var preOrderTraversal: [T] { get }
-    var postOrderTraversal: [T] { get }
-    func traverse(_ order: TraversalOrder, action: (T) -> ())
-}
-extension BinaryTreePr {
-    var isEmpty: Bool {
-        return count == 0
-    }
-    var inOrderTraversal: [T] {
-        var array: [T] = []
-        traverseInOrder(startingWith: root, action: { array.append($0) })
-        return array
-    }
-    var preOrderTraversal: [T] {
-        var array: [T] = []
-        traversePreOrder(startingWith: root, action: { array.append($0) })
-        return array
-    }
-    var postOrderTraversal: [T] {
-        var array: [T] = []
-        traversePostOrder(startingWith: root, action: { array.append($0) })
-        return array
-    }
-}
-extension BinaryTreePr {
-    func traverse(_ order: TraversalOrder, action: (T) -> ()) {
-        switch order {
-            case .preOrder:
-                traversePreOrder(startingWith: root, action: action)
-            case .inOrder:
-                traverseInOrder(startingWith: root, action: action)
-            case .postOrder:
-                traversePostOrder(startingWith: root, action: action)
-        }
-    }
-    private func traverseInOrder(startingWith node: Node?, action: (T) -> ()) {
-        if let node = node {
-            traverseInOrder(startingWith: node.leftChild as? Node, action: action)
-            action(node.value as! T)
-            traverseInOrder(startingWith: node.rightChild as? Node, action: action)
-        }
-    }
-    private func traversePreOrder(startingWith node: Node?, action: (T) -> ()) {
-        if let node = node {
-            action(node.value as! T)
-            traversePreOrder(startingWith: node.leftChild as? Node, action: action)
-            traversePreOrder(startingWith: node.rightChild as? Node, action: action)
-        }
-    }
-    private func traversePostOrder(startingWith node: Node?, action: (T) -> ()) {
-        if let node = node {
-            traversePostOrder(startingWith: node.leftChild as? Node, action: action)
-            traversePostOrder(startingWith: node.rightChild as? Node, action: action)
-            action(node.value as! T)
-        }
-    }
-}
+//enum TraversalOrder {
+//    /// Pre-order traversal first traverses the root, then the left subtree, and then the right subtree.
+//    case preOrder
+//    /// In-order traversal first traverses the left subtree, then the root, and then the right subtree.
+//    case inOrder
+//    /// Post-order traversal first traverses the left subtree, then the right subtree, and then the root.
+//    case postOrder
+//}
+//protocol BinaryTreePr {
+//    associatedtype T
+//    associatedtype Node where Node: BinaryTreeNodePr
+//    //associatedtype TraversalOrder
+//    var root: Node? { get }
+//    var count: Int { get }
+//    var isEmpty: Bool { get }
+//    var inOrderTraversal: [T] { get }
+//    var preOrderTraversal: [T] { get }
+//    var postOrderTraversal: [T] { get }
+//    func traverse(_ order: TraversalOrder, action: (T) -> ())
+//}
+//extension BinaryTreePr {
+//    var isEmpty: Bool {
+//        return count == 0
+//    }
+//    var inOrderTraversal: [T] {
+//        var array: [T] = []
+//        traverseInOrder(startingWith: root, action: { array.append($0) })
+//        return array
+//    }
+//    var preOrderTraversal: [T] {
+//        var array: [T] = []
+//        traversePreOrder(startingWith: root, action: { array.append($0) })
+//        return array
+//    }
+//    var postOrderTraversal: [T] {
+//        var array: [T] = []
+//        traversePostOrder(startingWith: root, action: { array.append($0) })
+//        return array
+//    }
+//}
+//extension BinaryTreePr {
+//    func traverse(_ order: TraversalOrder, action: (T) -> ()) {
+//        switch order {
+//            case .preOrder:
+//                traversePreOrder(startingWith: root, action: action)
+//            case .inOrder:
+//                traverseInOrder(startingWith: root, action: action)
+//            case .postOrder:
+//                traversePostOrder(startingWith: root, action: action)
+//        }
+//    }
+//    private func traverseInOrder(startingWith node: Node?, action: (T) -> ()) {
+//        if let node = node {
+//            traverseInOrder(startingWith: node.leftChild as? Node, action: action)
+//            action(node.value as! T)
+//            traverseInOrder(startingWith: node.rightChild as? Node, action: action)
+//        }
+//    }
+//    private func traversePreOrder(startingWith node: Node?, action: (T) -> ()) {
+//        if let node = node {
+//            action(node.value as! T)
+//            traversePreOrder(startingWith: node.leftChild as? Node, action: action)
+//            traversePreOrder(startingWith: node.rightChild as? Node, action: action)
+//        }
+//    }
+//    private func traversePostOrder(startingWith node: Node?, action: (T) -> ()) {
+//        if let node = node {
+//            traversePostOrder(startingWith: node.leftChild as? Node, action: action)
+//            traversePostOrder(startingWith: node.rightChild as? Node, action: action)
+//            action(node.value as! T)
+//        }
+//    }
+//}
 
 // MARK: - Tree
 class BinaryTree<T>: BinaryTreePr {

--- a/Learning/Data Structures/Trees/BinaryTree.swift
+++ b/Learning/Data Structures/Trees/BinaryTree.swift
@@ -125,40 +125,9 @@ class BinaryTree<T>: BinaryTreePr {
     
     /// The amount of elements (nodes) in the binary tree.
     /// - Complexity: O(1)
-    private(set) var count = 0
-    /// A Boolean value indicating whether the binary tree is empty.
-    /// - Complexity: O(1)
-//    var isEmpty: Bool {
-//        return count == 0
-//    }
-    
-    /// An array of objects traversed in-order.
-    ///
-    /// In-order traversal first traverses the left subtree, then the root, and then the right subtree.
-    /// - Complexity: O(*n*)
-//    var inOrderTraversal: [T] {
-//        var array: [T] = []
-//        traverseInOrder(startingWith: root, action: { array.append($0) })
-//        return array
-//    }
-    /// An array of objects traversed pre-order.
-    ///
-    /// Pre-order traversal first traverses the root, then the left subtree, and then the right subtree.
-    /// - Complexity: O(*n*)
-//    var preOrderTraversal: [T] {
-//        var array: [T] = []
-//        traversePreOrder(startingWith: root, action: { array.append($0) })
-//        return array
-//    }
-    /// An array of objects traversed post-order.
-    ///
-    /// Post-order traversal first traverses the left subtree, then the right subtree, and then the root.
-    /// - Complexity: O(*n*)
-//    var postOrderTraversal: [T] {
-//        var array: [T] = []
-//        traversePostOrder(startingWith: root, action: { array.append($0) })
-//        return array
-//    }
+    var count: Int {
+        return inOrderTraversal.count
+    }
     
     // MARK: - Initializers
     
@@ -176,55 +145,6 @@ class BinaryTree<T>: BinaryTreePr {
     }
     
 }
-
-// MARK: - Traversals
-//extension BinaryTree {
-//    /// The order in which the tree is traversed.
-//    enum TraversalOrder {
-//        /// Pre-order traversal first traverses the root, then the left subtree, and then the right subtree.
-//        case preOrder
-//        /// In-order traversal first traverses the left subtree, then the root, and then the right subtree.
-//        case inOrder
-//        /// Post-order traversal first traverses the left subtree, then the right subtree, and then the root.
-//        case postOrder
-//    }
-//    /// Traverses the tree in the specified order and performs an action on its elements. By default, the tree is traversed in-order.
-//    ///
-//    /// - Parameter order: The order in which the tree is traversed. In-order by default.
-//    /// - Parameter action: A closure that accepts an element of the tree and is called on every element during traversal.
-//    /// - Complexity: O(*n*)
-//    func traverse(_ order: TraversalOrder = .inOrder, action: (T) -> ()) {
-//        switch order {
-//            case .preOrder:
-//                traversePreOrder(startingWith: root, action: action)
-//            case .inOrder:
-//                traverseInOrder(startingWith: root, action: action)
-//            case .postOrder:
-//                traversePostOrder(startingWith: root, action: action)
-//        }
-//    }
-//    private func traverseInOrder(startingWith node: Node?, action: (T) -> ()) {
-//        if let node = node {
-//            traverseInOrder(startingWith: node.leftChild, action: action)
-//            action(node.value)
-//            traverseInOrder(startingWith: node.rightChild, action: action)
-//        }
-//    }
-//    private func traversePreOrder(startingWith node: Node?, action: (T) -> ()) {
-//        if let node = node {
-//            action(node.value)
-//            traversePreOrder(startingWith: node.leftChild, action: action)
-//            traversePreOrder(startingWith: node.rightChild, action: action)
-//        }
-//    }
-//    private func traversePostOrder(startingWith node: Node?, action: (T) -> ()) {
-//        if let node = node {
-//            traversePostOrder(startingWith: node.leftChild, action: action)
-//            traversePostOrder(startingWith: node.rightChild, action: action)
-//            action(node.value)
-//        }
-//    }
-//}
 
 // MARK: - Miscellaneous
 extension BinaryTreeNode: CustomStringConvertible where T: CustomStringConvertible {

--- a/Learning/Data Structures/Trees/BinaryTree.swift
+++ b/Learning/Data Structures/Trees/BinaryTree.swift
@@ -8,9 +8,7 @@
 
 // MARK: - Node
 class BinaryTreeNode<T>: BinaryTreeNodePr {
-    
-    //typealias Node = BinaryTreeNode<T>
-    
+        
     /// The value of the node.
     var value: T
     /// The left child of the node.
@@ -45,7 +43,7 @@ class BinaryTree<T>: BinaryTreePr {
         return inOrderTraversal.count
     }
     
-    // MARK: - Initializers
+    // MARK: Initializers
     
     /// Creates a new binary tree with the specified root.
     ///

--- a/Learning/Data Structures/Trees/BinaryTree.swift
+++ b/Learning/Data Structures/Trees/BinaryTree.swift
@@ -7,7 +7,7 @@
 //
 
 // MARK: - Node
-class BinaryTreeNode<T>: BinaryTreeNodePr {
+class BinaryTreeNode<T>: AnyBinaryTreeNode {
         
     /// The value of the node.
     var value: T
@@ -28,7 +28,7 @@ class BinaryTreeNode<T>: BinaryTreeNodePr {
 }
 
 // MARK: - Tree
-class BinaryTree<T>: BinaryTreePr {
+class BinaryTree<T>: AnyBinaryTree {
     
     typealias Node = BinaryTreeNode<T>
     

--- a/Learning/Data Structures/Trees/BinaryTree.swift
+++ b/Learning/Data Structures/Trees/BinaryTree.swift
@@ -6,15 +6,15 @@
 //  Copyright © 2020 Artem Zhukov. All rights reserved.
 //
 
-protocol BinaryTreeNodePr {
-    associatedtype T
-    associatedtype Node = Self
-    var value: T { get set }
-    var leftChild: Node? { get set }
-    var rightChild: Node? { get set }
-    var parent: Node? { get set }
-    //init(_ value: T)
-}
+//protocol BinaryTreeNodePr {
+//    associatedtype T
+//    associatedtype Node = Self
+//    var value: T { get set }
+//    var leftChild: Node? { get set }
+//    var rightChild: Node? { get set }
+//    var parent: Node? { get set }
+//    //init(_ value: T)
+//}
 
 // MARK: - Node
 class BinaryTreeNode<T>: BinaryTreeNodePr {

--- a/Learning/Data Structures/Trees/BinaryTree.swift
+++ b/Learning/Data Structures/Trees/BinaryTree.swift
@@ -60,7 +60,7 @@ class BinaryTree<T>: AnyBinaryTree {
     
 }
 
-extension BinaryTreeNode: StringConvertibleBinaryTree where T: CustomStringConvertible {}
+extension BinaryTreeNode: StringConvertibleBinarySubtree where T: CustomStringConvertible {}
 extension BinaryTreeNode: CustomStringConvertible where T: CustomStringConvertible {}
 
 extension BinaryTree: CustomStringConvertible where T: CustomStringConvertible {

--- a/Learning/Data Structures/Trees/BinaryTree.swift
+++ b/Learning/Data Structures/Trees/BinaryTree.swift
@@ -86,41 +86,7 @@ extension BinaryTreeNode: CustomStringConvertible where T: CustomStringConvertib
     var description: String {
         var string: [[Character]] = []
         constructString(&string, 0) // O(nlogn)
-        var maxLineLength = 0
-        for line in 0..<string.count {  // indent all lines (for a e s t h e t i c s) O(n^2)
-            let first = string[line][0]
-            if first != "│" && first != "┌" && first != "└" {
-                string[line] = "──── " + string[line] // O(n)
-            } else {
-                string[line] = "     " + string[line] // O(n)
-            }
-            maxLineLength = max(maxLineLength, string[line].count)
-        }
-        for col in stride(from: 0, to: maxLineLength, by: 5) { // O(n^2)
-            var removing = true
-            for row in 0..<string.count {
-                if col >= string[row].count {
-                    removing = true
-                    continue
-                }
-                let character = string[row][col]
-                if col > 0 && character != "│" && character != "┌" && character != "└" && string[row][col-1] != " " {
-                    removing = true
-                    continue
-                }
-                if character == "┌" {
-                    removing = false
-                }
-                if removing && character == "│" {
-                    string[row][col] = " "
-                } else if removing {
-                    removing = false
-                }
-                if character == "└" {
-                    removing = true
-                }
-            }
-        }
+        clean(string: &string)
         return String(string.joined(separator: "\n"))
         // O(nlogn + n^2) = O(n^2)
     }

--- a/Learning/Data Structures/Trees/BinaryTree.swift
+++ b/Learning/Data Structures/Trees/BinaryTree.swift
@@ -6,19 +6,29 @@
 //  Copyright © 2020 Artem Zhukov. All rights reserved.
 //
 
+protocol BinaryTreeNodePr {
+    associatedtype T
+    associatedtype Node = Self
+    var value: T { get set }
+    var leftChild: Node? { get set }
+    var rightChild: Node? { get set }
+    var parent: Node? { get set }
+    //init(_ value: T)
+}
+
 // MARK: - Node
-class BinaryTreeNode<T: Comparable> {
+class BinaryTreeNode<T>: BinaryTreeNodePr {
     
-    typealias Node = BinaryTreeNode<T>
+    //typealias Node = BinaryTreeNode<T>
     
     /// The value of the node.
     var value: T
     /// The left child of the node.
-    var leftChild: Node?
+    var leftChild: BinaryTreeNode<T>?
     /// The right child of the node.
-    var rightChild: Node?
+    var rightChild: BinaryTreeNode<T>?
     /// The parent node of the node.
-    weak var parent: Node?
+    weak var parent: BinaryTreeNode<T>?
     
     /// Creates a node with the given value.
     /// - Parameter key: The value of the node.

--- a/Learning/Data Structures/Trees/Heap.swift
+++ b/Learning/Data Structures/Trees/Heap.swift
@@ -6,10 +6,48 @@
 //  Copyright © 2020 Artem Zhukov. All rights reserved.
 //
 
-class MaxHeap<T>: BinarySearchTree<T> where T: Comparable {
+class Heap<T> {
     
-}
-
-class MinHeap<T>: BinarySearchTree<T> where T: Comparable {
+    private let areInIncreasingOrder: (T, T) -> Bool
+    private var heap: [T] = []
+    
+    init(_ comparator: @escaping (T, T) -> Bool) {
+        self.areInIncreasingOrder = comparator
+    }
+    
+    init(_ comparator: @escaping (T, T) -> Bool, contentsOf array: [T]) {
+        self.heap = array
+        self.areInIncreasingOrder = comparator
+        for i in stride(from: (array.count - 1)/2, through: 0, by: -1) {
+            heapifyDown(i)
+        }
+    }
+    
+    private func heapifyUp(_ index: Int) {
+        if index > 0 {
+            let j = (index - 1)/2
+            if areInIncreasingOrder(heap[index], heap[j]) {
+                heap.swapAt(index, j)
+                heapifyUp(j)
+            }
+        }
+    }
+    
+    private func heapifyDown(_ index: Int) {
+        let n = heap.count - 1
+        let j: Int
+        if 2*index + 1 > n {
+            return
+        } else if 2*index + 1 < n {
+            let left = 2*index + 1, right = 2*index + 2
+            j = (areInIncreasingOrder(heap[left], heap[right])) ? left : right
+        } else {
+            j = 2*index + 1
+        }
+        if areInIncreasingOrder(heap[j], heap[index]) {
+            heap.swapAt(j, index)
+            heapifyDown(j)
+        }
+    }
     
 }


### PR DESCRIPTION
All reusable code has been moved to protocols:
- `AnyBinaryTree`
- `AnyBinaryTreeNode`
- `StringConvertibleBinarySubtree`